### PR TITLE
fix nameplates become invisible or stuck in name-only mode (close #10, close #6)

### DIFF
--- a/Main.lua
+++ b/Main.lua
@@ -38,18 +38,17 @@ local function onModuleStart()
 	---@param nameplate Frame
 	function TRPKN.HideKuiNameplate(nameplate)
 		nameplate.state.no_name = true
-		nameplate.IN_NAMEONLY = false
-		nameplate:UpdateNameText();
-		nameplate:UpdateGuildText()
+		nameplate:UpdateNameText()
+		nameplate:UpdateLevelText()
+		nameplate:UpdateFrameSize()
+		nameplate.NameText:Hide()
+		nameplate.GuildText:Hide()
 	end
 
 	---ShowKuiNameplate
 	---@param nameplate Frame
 	function TRPKN.ShowKuiNameplate(nameplate)
-		nameplate.state.no_name = false
-		nameplate.IN_NAMEONLY = true
-		nameplate:UpdateNameText();
-		nameplate:UpdateGuildText();
+		addon.layout:Show(nameplate)
 	end
 
 

--- a/Main.lua
+++ b/Main.lua
@@ -20,19 +20,20 @@
 local TRPKN = select(2, ...);
 
 local function onModuleStart()
-	
+
 	local addon = KuiNameplates;
 	local mod = addon:NewPlugin('Total RP 3: KuiNameplates', 200);
 	local nameTextMod = addon:GetPlugin("NameText");
 	local guildTextMod = addon:GetPlugin("GuildText");
-	
-	
+	local loc = TRP3_API.loc;
+
+
 	local getConfigValue = TRP3_API.configuration.getValue;
-	
+
 	local isPlayerIC = TRP3_API.dashboard.isPlayerIC;
 	local UnitIsPlayer = UnitIsPlayer;
 	local UnitIsOtherPlayersPet = UnitIsOtherPlayersPet;
-	
+
 	---HideKuiNameplate
 	---@param nameplate Frame
 	function TRPKN.HideKuiNameplate(nameplate)
@@ -41,7 +42,7 @@ local function onModuleStart()
 		nameplate:UpdateNameText();
 		nameplate:UpdateGuildText()
 	end
-	
+
 	---ShowKuiNameplate
 	---@param nameplate Frame
 	function TRPKN.ShowKuiNameplate(nameplate)
@@ -50,8 +51,8 @@ local function onModuleStart()
 		nameplate:UpdateNameText();
 		nameplate:UpdateGuildText();
 	end
-	
-	
+
+
 	---
 	-- Update the nameplate with informations we get from the Total RP 3 API
 	-- @param nameplate
@@ -60,50 +61,65 @@ local function onModuleStart()
 
 		-- TRP3_API.Ellyb.Tables.inspect(nameplate)
 		if not nameplate.unit -- If we don't have a unit
-			or nameplate.state.player --  or this is the personal nameplate
+			or nameplate.state.personal --  or this is the personal nameplate
 			or not nameplate.state.friend -- or this is an enemy
 		then
 			return -- we can stop here
 		end;
-		
+
 		nameTextMod:Show(nameplate);
 		guildTextMod:Show(nameplate);
 		TRPKN.ShowKuiNameplate(nameplate);
-		
+
 		-- Only continue if the customization has not be disabled manually and check if we are in character if the option is checked
 		if not getConfigValue(TRPKN.CONFIG.ENABLE_NAMEPLATES_CUSTOMIZATION) or (getConfigValue(TRPKN.CONFIG.DISPLAY_NAMEPLATES_ONLY_IN_CHARACTER) and not isPlayerIC()) then
 			return
 		end;
-		
+
+		-- TRP3's customizations are overridden when Kui Nameplates' option to show player title is enabled, so we will disable it manually.
+		-- I don't like that either, but the complexity of getting all of this to work is too much for me right now, I'll go back on this later.
+		if KuiNameplatesCore.config and type(KuiNameplatesCore.config.GetActiveProfile) == "function" then
+			local kuiNameplatesCurrentConfigProfile = KuiNameplatesCore.config:GetActiveProfile();
+			if type(kuiNameplatesCurrentConfigProfile) == "table" then
+				if kuiNameplatesCurrentConfigProfile["title_text_players"] == true then
+					TRP3_API.utils.message.displayMessage(loc.KNP_MODULE .. ": " .. loc.KNP_TITLES_WARNING)
+					kuiNameplatesCurrentConfigProfile["title_text_players"] = false;
+					KuiNameplatesCore:SetLocals();
+				end
+			end
+		end
+
 		if getConfigValue(TRPKN.CONFIG.HIDE_NON_ROLEPLAY) and UnitIsPlayer(nameplate.unit) or UnitIsOtherPlayersPet(nameplate.unit) then
 			TRPKN.HideKuiNameplate(nameplate);
 		end
-		
+
 		-- Check if the unit is a player)
 		if UnitIsPlayer(nameplate.unit) then
 			TRPKN.modifyPlayerNameplate(nameplate);
 		else
 			TRPKN.modifyPetNameplate(nameplate);
 		end
-	
-	
+
+
 	end
-	
+
 	function TRPKN.refreshAllNameplates()
 		for _, nameplate in addon:Frames() do
-			mod:UpdateRPName(nameplate);
+			if nameplate:IsShown() then
+				mod:UpdateRPName(nameplate);
+			end
 		end
 	end
-	
+
 	mod.RefreshAllNameplates = TRPKN.refreshAllNameplates;
-	
+
 	function mod:Initialise()
 		self:RegisterMessage('Create', 'RefreshAllNameplates');
 		self:RegisterMessage('Show', 'UpdateRPName');
 		self:RegisterMessage('GainedTarget', 'UpdateRPName');
 		self:RegisterMessage('LostTarget', 'UpdateRPName');
 	end
-	
+
 	-- We listen to the register data update event fired by Total RP 3 when we receive new data
 	-- about a player.
 	-- It's not super efficient, but we will refresh all RP names on all nameplates for now


### PR DESCRIPTION
This repo is out of date, so see the correct diff in 226ad1998cc9e9f7ac99479c89a121558da4570a

I'm pretty sure you knew this way of making nameplates invisible was a hack, but in particular, editing IN_NAMEONLY was confusing KNP because it's a persistent thing and stuff and etc., anyway, this method just hides names and guilds without trying to hide the health bar. So, if the player has name-only mode on for friendly players, then this still completely hides them. If they have the health bar visible, then the nameplates just become nameless (which is a state knp already has) - the health bar stays visible and.. and becomes a bit thinner.

If that works for you, then there you go.

Otherwise, it might also be possible to make a "fade rule" for this; that would just make frames invisible if they don't have an RP name (and they're friendly, etc).