### PR TITLE
Added a new config key for nameplate indicator

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -37,7 +37,7 @@ function TRPKN.initConfig()
 	TRPKN.CONFIG.PET_NAMES = "kui_nameplates_pet_names";
 	TRPKN.CONFIG.SHOW_OOC_INDICATOR = "kui_nameplates_show_ooc_indicator";
 	TRPKN.CONFIG.ACTIVE_QUERY = "kui_nameplates_active_query";
-	TRPKN.CONFIG.PREFER_OOC_ICON = "kui_nameplates_prefere_ooc_icon";
+	TRPKN.CONFIG.PREFER_OOC_ICON = "kui_nameplates_preferred_ooc_icon";
 	local OOC_ICON = "|TInterface\\COMMON\\Indicator-Red:15:15|t";
 	local OOC_INDICATOR_TYPES = {
 		{loc.CO_TOOLTIP_PREFERRED_OOC_INDICATOR_TEXT .. TRP3_API.Ellyb.ColorManager.RED("[" .. loc.CM_OOC .. "] "), "TEXT"},

--- a/Config.lua
+++ b/Config.lua
@@ -37,6 +37,12 @@ function TRPKN.initConfig()
 	TRPKN.CONFIG.PET_NAMES = "kui_nameplates_pet_names";
 	TRPKN.CONFIG.SHOW_OOC_INDICATOR = "kui_nameplates_show_ooc_indicator";
 	TRPKN.CONFIG.ACTIVE_QUERY = "kui_nameplates_active_query";
+	TRPKN.CONFIG.PREFER_OOC_ICON = "kui_nameplates_prefere_ooc_icon";
+	local OOC_ICON = "|TInterface\\COMMON\\Indicator-Red:15:15|t";
+	local OOC_INDICATOR_TYPES = {
+		{loc.CO_TOOLTIP_PREFERRED_OOC_INDICATOR_TEXT .. TRP3_API.Ellyb.ColorManager.RED("[" .. loc.CM_OOC .. "] "), "TEXT"},
+		{loc.CO_TOOLTIP_PREFERRED_OOC_INDICATOR_ICON .. OOC_ICON, "ICON"}
+	}
 	
 	registerConfigKey(TRPKN.CONFIG.ENABLE_NAMEPLATES_CUSTOMIZATION, true);
 	registerConfigKey(TRPKN.CONFIG.DISPLAY_NAMEPLATES_ONLY_IN_CHARACTER, true);
@@ -47,6 +53,7 @@ function TRPKN.initConfig()
 	registerConfigKey(TRPKN.CONFIG.SHOW_TITLES, false);
 	registerConfigKey(TRPKN.CONFIG.SHOW_OOC_INDICATOR, true);
 	registerConfigKey(TRPKN.CONFIG.ACTIVE_QUERY, true);
+	registerConfigKey(TRPKN.CONFIG.PREFER_OOC_ICON, TRP3_Configuration.tooltip_prefere_ooc_icon or "TEXT");
 	
 	registerHandler(TRPKN.CONFIG.ENABLE_NAMEPLATES_CUSTOMIZATION, TRPKN.refreshAllNameplates);
 	registerHandler(TRPKN.CONFIG.DISPLAY_NAMEPLATES_ONLY_IN_CHARACTER, TRPKN.refreshAllNameplates);
@@ -56,6 +63,7 @@ function TRPKN.initConfig()
 	registerHandler(TRPKN.CONFIG.SHOW_TITLES, TRPKN.refreshAllNameplates);
 	registerHandler(TRPKN.CONFIG.PET_NAMES, TRPKN.refreshAllNameplates);
 	registerHandler(TRPKN.CONFIG.SHOW_OOC_INDICATOR, TRPKN.refreshAllNameplates);
+	registerHandler(TRPKN.CONFIG.PREFER_OOC_ICON, TRPKN.refreshAllNameplates);
 	
 	-- Build configuration page
 	registerConfigurationPage({
@@ -112,6 +120,14 @@ function TRPKN.initConfig()
 				title = loc.KNP_SHOW_OOC_INDICATOR,
 				configKey = TRPKN.CONFIG.SHOW_OOC_INDICATOR,
 				dependentOnOptions = { TRPKN.CONFIG.ENABLE_NAMEPLATES_CUSTOMIZATION },
+			},
+			{
+				inherit = "TRP3_ConfigDropDown",
+				title = loc.CO_TOOLTIP_PREFERRED_OOC_INDICATOR,
+				listContent = OOC_INDICATOR_TYPES,
+				configKey = TRPKN.CONFIG.PREFER_OOC_ICON,
+				listWidth = nil,
+				listCancel = true,
 			},
 			{
 				inherit = "TRP3_ConfigCheck",

--- a/Config.lua
+++ b/Config.lua
@@ -37,7 +37,7 @@ function TRPKN.initConfig()
 	TRPKN.CONFIG.PET_NAMES = "kui_nameplates_pet_names";
 	TRPKN.CONFIG.SHOW_OOC_INDICATOR = "kui_nameplates_show_ooc_indicator";
 	TRPKN.CONFIG.ACTIVE_QUERY = "kui_nameplates_active_query";
-	TRPKN.CONFIG.PREFER_OOC_ICON = "kui_nameplates_preferred_ooc_icon";
+	TRPKN.CONFIG.PREFERRED_OOC_ICON = "kui_nameplates_preferred_ooc_icon";
 	local OOC_ICON = "|TInterface\\COMMON\\Indicator-Red:15:15|t";
 	local OOC_INDICATOR_TYPES = {
 		{loc.CO_TOOLTIP_PREFERRED_OOC_INDICATOR_TEXT .. TRP3_API.Ellyb.ColorManager.RED("[" .. loc.CM_OOC .. "] "), "TEXT"},
@@ -53,7 +53,7 @@ function TRPKN.initConfig()
 	registerConfigKey(TRPKN.CONFIG.SHOW_TITLES, false);
 	registerConfigKey(TRPKN.CONFIG.SHOW_OOC_INDICATOR, true);
 	registerConfigKey(TRPKN.CONFIG.ACTIVE_QUERY, true);
-	registerConfigKey(TRPKN.CONFIG.PREFER_OOC_ICON, TRP3_Configuration.tooltip_prefere_ooc_icon or "TEXT");
+	registerConfigKey(TRPKN.CONFIG.PREFERRED_OOC_ICON, TRP3_Configuration.tooltip_prefere_ooc_icon or "TEXT");
 	
 	registerHandler(TRPKN.CONFIG.ENABLE_NAMEPLATES_CUSTOMIZATION, TRPKN.refreshAllNameplates);
 	registerHandler(TRPKN.CONFIG.DISPLAY_NAMEPLATES_ONLY_IN_CHARACTER, TRPKN.refreshAllNameplates);
@@ -63,7 +63,7 @@ function TRPKN.initConfig()
 	registerHandler(TRPKN.CONFIG.SHOW_TITLES, TRPKN.refreshAllNameplates);
 	registerHandler(TRPKN.CONFIG.PET_NAMES, TRPKN.refreshAllNameplates);
 	registerHandler(TRPKN.CONFIG.SHOW_OOC_INDICATOR, TRPKN.refreshAllNameplates);
-	registerHandler(TRPKN.CONFIG.PREFER_OOC_ICON, TRPKN.refreshAllNameplates);
+	registerHandler(TRPKN.CONFIG.PREFERRED_OOC_ICON, TRPKN.refreshAllNameplates);
 	
 	-- Build configuration page
 	registerConfigurationPage({
@@ -125,7 +125,7 @@ function TRPKN.initConfig()
 				inherit = "TRP3_ConfigDropDown",
 				title = loc.CO_TOOLTIP_PREFERRED_OOC_INDICATOR,
 				listContent = OOC_INDICATOR_TYPES,
-				configKey = TRPKN.CONFIG.PREFER_OOC_ICON,
+				configKey = TRPKN.CONFIG.PREFERRED_OOC_ICON,
 				listWidth = nil,
 				listCancel = true,
 			},

--- a/PlayerNameplates.lua
+++ b/PlayerNameplates.lua
@@ -30,9 +30,8 @@ function TRPKN.initPlayerNameplates()
 
 	local profilesRequestByUnitForThisSession = {}
 
-	local CONFIG_PREFER_OOC_ICON = "tooltip_prefere_ooc_icon";
 	local OOC_TEXT_INDICATOR = TRP3_API.Ellyb.ColorManager.RED("[" .. loc.CM_OOC .. "] ");
-	local OOC_ICON_INDICATOR = TRP3_API.Ellyb.Icon([[Interface\COMMON\Indicator-Red]], 15)
+	local OOC_ICON_INDICATOR = TRP3_API.Ellyb.Icon([[Interface\COMMON\Indicator-Red]], 15);
 
 	local MAX_TITLE_SIZE = 40;
 
@@ -67,7 +66,7 @@ function TRPKN.initPlayerNameplates()
 		--{{{ Player name
 		local name = player:GetRoleplayingName();
 		if getConfigValue(TRPKN.CONFIG.SHOW_OOC_INDICATOR) and not player:IsInCharacter() then
-			if getConfigValue(CONFIG_PREFER_OOC_ICON) == "TEXT" then
+			if getConfigValue(TRPKN.CONFIG.PREFER_OOC_ICON) == "TEXT" then
 				name = OOC_TEXT_INDICATOR .. " " .. name;
 			else
 				name = OOC_ICON_INDICATOR .. " " .. name
@@ -109,8 +108,4 @@ function TRPKN.initPlayerNameplates()
 			TRPKN.ShowKuiNameplate(nameplate);
 		end
 	end
-
-	TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
-		TRP3_API.configuration.registerHandler(CONFIG_PREFER_OOC_ICON, TRPKN.refreshAllNameplates);
-	end)
 end

--- a/PlayerNameplates.lua
+++ b/PlayerNameplates.lua
@@ -66,7 +66,7 @@ function TRPKN.initPlayerNameplates()
 		--{{{ Player name
 		local name = player:GetRoleplayingName();
 		if getConfigValue(TRPKN.CONFIG.SHOW_OOC_INDICATOR) and not player:IsInCharacter() then
-			if getConfigValue(TRPKN.CONFIG.PREFER_OOC_ICON) == "TEXT" then
+			if getConfigValue(TRPKN.CONFIG.PREFERRED_OOC_ICON) == "TEXT" then
 				name = OOC_TEXT_INDICATOR .. " " .. name;
 			else
 				name = OOC_ICON_INDICATOR .. " " .. name


### PR DESCRIPTION
The KNP module was reading the tooltip setting for the OOC indicator to know what to show on nameplates. Except we shouldn't trust the tooltip module to be enabled (and if disabled, the whole addon just collapses if OOC indicator is to be shown on nameplates).

A new setting will be added, reading from the tooltip setting (which will likely be there but there's still a fallback just in case). This way we can disable the tooltip module without the addon losing its shit.