### PR TITLE
Some bugfixes for nameplates display

### DIFF
--- a/Main.lua
+++ b/Main.lua
@@ -88,7 +88,7 @@ local function onModuleStart()
 			end
 		end
 
-		if getConfigValue(TRPKN.CONFIG.HIDE_NON_ROLEPLAY) and UnitIsPlayer(nameplate.unit) or UnitIsOtherPlayersPet(nameplate.unit) then
+		if getConfigValue(TRPKN.CONFIG.HIDE_NON_ROLEPLAY) and (UnitIsPlayer(nameplate.unit) or UnitIsOtherPlayersPet(nameplate.unit)) then
 			TRPKN.HideKuiNameplate(nameplate);
 		end
 

--- a/PlayerNameplates.lua
+++ b/PlayerNameplates.lua
@@ -96,7 +96,10 @@ function TRPKN.initPlayerNameplates()
 			-- TODO Switch to newer API when available
 			-- local title = player:GetFullTitle();
 			local profile = player:GetProfile()
-			local title = profile.characteristics.FT
+			local title;
+			if profile and profile.characteristics then
+				title = profile.characteristics.FT
+			end
 			if title then
 				nameplate.state.guild_text = "<" .. crop(title, MAX_TITLE_SIZE) .. ">";
 			else

--- a/PlayerNameplates.lua
+++ b/PlayerNameplates.lua
@@ -58,11 +58,7 @@ function TRPKN.initPlayerNameplates()
 				profilesRequestByUnitForThisSession[characterID] = true
 			end
 
-			if getConfigValue(TRPKN.CONFIG.HIDE_NON_ROLEPLAY) then
-				TRPKN.HideKuiNameplate(nameplate);
-			end
-
-			return false;
+			return;
 		end
 
 		--{{{ Player name
@@ -76,15 +72,6 @@ function TRPKN.initPlayerNameplates()
 		end
 		nameplate.state.name = name;
 		nameplate.NameText:SetText(nameplate.state.name);
-		--}}}
-
-		--{{{ Custom color
-		if getConfigValue(TRPKN.CONFIG.USE_CUSTOM_COLOR) then
-			local customColor = player:GetCustomColorForDisplay();
-			if customColor then
-				nameplate.NameText:SetTextColor(customColor:GetRGB())
-			end
-		end
 		--}}}
 
 		--{{{ Titles
@@ -112,6 +99,15 @@ function TRPKN.initPlayerNameplates()
 		if getConfigValue(TRPKN.CONFIG.HIDE_NON_ROLEPLAY) then
 			TRPKN.ShowKuiNameplate(nameplate);
 		end
+
+		--{{{ Custom color
+		if getConfigValue(TRPKN.CONFIG.USE_CUSTOM_COLOR) then
+			local customColor = player:GetCustomColorForDisplay();
+			if customColor then
+				nameplate.NameText:SetTextColor(customColor:GetRGB())
+			end
+		end
+		--}}}
 	end
 
 	TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()


### PR DESCRIPTION
- The check for hiding pet names with no profile when the setting is enabled was incorrect, `and` has priority over `or`.
- We're showing all nameplates and only hiding them again if the setting to hide non-RP is enabled before getting to the customisation part, so we don't need to re-hide them in the player nameplate function.
- Nil check when custom titles are enabled to make sure we have characteristics
- Colours were applied before showing the nameplate, which doesn't work if the nameplate was hidden before (meaning if the setting to hide non-RP is enabled)